### PR TITLE
Don't use user-provided ClassLoader for DatabaseTypeRegister

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/Flyway.java
@@ -139,7 +139,6 @@ public class Flyway {
         this.configuration.loadCallbackLocation("db/callback", false);
 
         // Set ClassLoader for ServiceLoader
-        DatabaseTypeRegister.classLoader = configuration.getClassLoader();
         VersionPrinter.classLoader = configuration.getClassLoader();
     }
 


### PR DESCRIPTION
As seen in flyway#3177, DatabaseTypeRegister shouldn't really be using the classloader provided in the configuration. In OSGI, this causes Flyway to be unable to find the database drivers, since they are only visible to the Flyway bundle and the user's bundle is only really needed to provide resources like SQL migrations.